### PR TITLE
Fix newline issue with encrypting URLs

### DIFF
--- a/kms-util
+++ b/kms-util
@@ -51,8 +51,7 @@ then
 
   >&2 echo Encrypting with profile: $PROFILE
   if [[ $INPUT == http* ]]; then
-    >&2 echo "Interpretting input as http* URL; Encrypted value may include \r\n when decrypted"
-    RESULT=$(AWS_DEFAULT_REGION=us-east-1 aws kms encrypt --key-id $KEY_ID --profile $PROFILE --query CiphertextBlob --output text --plaintext fileb://<( echo "$INPUT"))
+    RESULT=$(AWS_DEFAULT_REGION=us-east-1 aws kms encrypt --key-id $KEY_ID --profile $PROFILE --query CiphertextBlob --output text --plaintext fileb://<( echo -n "$INPUT"))
   else
     RESULT=$(AWS_DEFAULT_REGION=us-east-1 aws kms encrypt --key-id $KEY_ID --profile $PROFILE --query CiphertextBlob --output text --plaintext "$INPUT" --cli-binary-format raw-in-base64-out)
   fi


### PR DESCRIPTION
Adds `-n` to `echo` when encrypting URLs to omit the newline.

`kms encrypt` takes a `--plaintext` param containing the plaintext value to encrypt. However, if it detects it's a URL, it fetches the contents of the URL and encrypts that as if that makes any sense. Consequently, we have to do some acrobatics to hide the fact that we're encrypting a URL by passing the URL value via `echo`. Since `echo` adds a newline, we've had the problem that encrypted URLs have a newline at the end when decrypted, which creates problems for some apps. This update adds the `-n` param to `echo` to omit the newline so that only the URL itself is encrypted.